### PR TITLE
add missing Dockerfile.test file in vendor directory

### DIFF
--- a/vendor/github.com/getsentry/raven-go/Dockerfile.test
+++ b/vendor/github.com/getsentry/raven-go/Dockerfile.test
@@ -1,0 +1,13 @@
+FROM golang:1.7
+
+RUN mkdir -p /go/src/github.com/getsentry/raven-go
+WORKDIR /go/src/github.com/getsentry/raven-go
+ENV GOPATH /go
+
+RUN go install -race std && go get golang.org/x/tools/cmd/cover
+
+COPY . /go/src/github.com/getsentry/raven-go
+
+RUN go get -v ./...
+
+CMD ["./runtests.sh"]


### PR DESCRIPTION
builds were failing when checking for consistency in the vendor
directory because this file was missing. Adding it in to resolve build
issues.

references: https://github.com/open-cluster-management/backlog/issues/17047

Signed-off-by: arewm <arewm@users.noreply.github.com>